### PR TITLE
APIのデータをScreenに反映、SDK ver.のアップデート

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -31,7 +31,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.nns.qiitamitsuke.qiitamitsuketatter"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/lib/ui/screen/detail_screen.dart
+++ b/lib/ui/screen/detail_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:qiita_mitsuke_tatter/model/topic.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:url_launcher/url_launcher.dart' as Browser;
 
 import 'package:qiita_mitsuke_tatter/theme.dart';
 
@@ -11,6 +13,7 @@ class DetailScreen extends StatefulWidget {
   @override
   _DetailScreen createState() => new _DetailScreen();
 }
+
 // ガバッと開いているときのAppBarのサイズ
 const double _kAppBarHeight = 200.0;
 
@@ -61,7 +64,7 @@ Widget buildAppBarTitle(
     fontSize: 18.0,
     color: Colors.white,
   ));
-  final Curve _textOpacity = const Interval(0.4, 1.0, curve: Curves.easeInOut);
+  final Curve _textOpacity = const Interval(0.2, 1.0, curve: Curves.easeInOut);
   final Size screenSize = MediaQuery.of(context).size;
   final double titleWidth =
       screenSize.width - kToolbarHeight - NavigationToolbar.kMiddleSpacing;
@@ -91,7 +94,7 @@ Widget buildAppBarTitle(
 }
 
 Widget buildHeader(Topic topic, double t) {
-  final Curve _textOpacity = const Interval(0.4, 1.0, curve: Curves.easeInOut);
+  final Curve _textOpacity = const Interval(0.7, 1.0, curve: Curves.easeInOut);
 
   return new Opacity(
     // 上にスクロールすると徐々に消えていく
@@ -124,17 +127,25 @@ Widget buildBody(Topic topic, BuildContext context) {
             constraints: new BoxConstraints(
                 minHeight: MediaQuery.of(context).size.height -
                     MediaQuery.of(context).padding.top -
-                    kToolbarHeight),
+                    kToolbarHeight -
+                    50
+            ),
             margin: const EdgeInsets.only(top: 16.0),
-            child: new Text(
-              topic.body,
-              style: detailStyle,
+            child: new MarkdownBody(
+              data: topic.body,
+              onTapLink: (url) => launchInBrowser(url),
             ),
           ),
         ],
       ),
     ),
   );
+}
+
+launchInBrowser(String url) async {
+  if (await Browser.canLaunch(url)) {
+    await Browser.launch(url, forceSafariVC: true, forceWebView: true);
+  }
 }
 
 Widget buildTitle(String title) {

--- a/lib/ui/screen/detail_screen.dart
+++ b/lib/ui/screen/detail_screen.dart
@@ -1,22 +1,79 @@
 import 'package:flutter/material.dart';
+import 'package:qiita_mitsuke_tatter/model/topic.dart';
+
+import 'package:qiita_mitsuke_tatter/theme.dart';
 
 class DetailScreen extends StatefulWidget {
-  DetailScreen({Key key, this.title}) : super(key: key);
+  DetailScreen({Key key, this.topic}) : super(key: key);
 
-  final String title;
+  final Topic topic;
 
   @override
   _DetailScreen createState() => new _DetailScreen();
 }
 
 class _DetailScreen extends State<DetailScreen> {
-
   @override
   Widget build(BuildContext context) {
-    return new Scaffold(
-      appBar: new AppBar(
-        title: new Text(widget.title),
-      ),
-    );
+    return new Theme(
+        data: themeData,
+        child: new Scaffold(
+          body: new CustomScrollView(
+            slivers: [
+              new SliverAppBar(
+                pinned: false,
+                expandedHeight: 200.0,
+                flexibleSpace: new LayoutBuilder(
+                  builder: (BuildContext context, BoxConstraints constraints) {
+                    return new Container(
+                        alignment: Alignment.bottomLeft,
+                        child: new Column(
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            buildTitle(widget.topic.title),
+                            buildHeaderContents(widget.topic.user.imageUrl,
+                                widget.topic.user.id),
+                          ],
+                        ));
+                  },
+                ),
+              ),
+            ],
+          ),
+        ));
   }
+}
+
+Widget buildTitle(title) {
+  return new Padding(
+    child: new Text(
+      title,
+      style: new TextStyle(
+        fontSize: 20.0,
+        color: Colors.white,
+      ),
+    ),
+    padding: new EdgeInsets.all(16.0),
+  );
+}
+
+Widget buildHeaderContents(imageUrl, name) {
+  return new Row(
+    children: <Widget>[
+      new Padding(
+        padding: new EdgeInsets.fromLTRB(8.0, 0.0, 8.0, 8.0),
+        child: new CircleAvatar(
+          backgroundImage: imageUrl != null ? new NetworkImage(imageUrl) : null,
+        ),
+      ),
+      new Text(
+        name,
+        style: new TextStyle(
+          fontSize: 16.0,
+          color: Colors.white,
+        ),
+      ),
+    ],
+  );
 }

--- a/lib/ui/screen/detail_screen.dart
+++ b/lib/ui/screen/detail_screen.dart
@@ -11,42 +11,134 @@ class DetailScreen extends StatefulWidget {
   @override
   _DetailScreen createState() => new _DetailScreen();
 }
+// ガバッと開いているときのAppBarのサイズ
+const double _kAppBarHeight = 200.0;
 
 class _DetailScreen extends State<DetailScreen> {
   @override
   Widget build(BuildContext context) {
     return new Theme(
-        data: themeData,
-        child: new Scaffold(
-          body: new CustomScrollView(
-            slivers: [
-              new SliverAppBar(
-                pinned: false,
-                expandedHeight: 200.0,
-                flexibleSpace: new LayoutBuilder(
-                  builder: (BuildContext context, BoxConstraints constraints) {
-                    return new Container(
-                        alignment: Alignment.bottomLeft,
-                        child: new Column(
-                          mainAxisAlignment: MainAxisAlignment.end,
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            buildTitle(widget.topic.title),
-                            buildHeaderContents(widget.topic.user.imageUrl,
-                                widget.topic.user.id),
-                          ],
-                        ));
-                  },
-                ),
-              ),
-            ],
-          ),
-        ));
+      data: themeData,
+      child: new Scaffold(
+        body: new CustomScrollView(
+          slivers: <Widget>[
+            buildAppBar(widget.topic, context),
+            buildBody(widget.topic, context),
+          ],
+        ),
+      ),
+    );
   }
 }
 
-Widget buildTitle(title) {
-  return new Padding(
+Widget buildAppBar(Topic topic, BuildContext context) {
+  final double statusBarHeight = MediaQuery.of(context).padding.top;
+
+  return new SliverAppBar(
+    pinned: true,
+    expandedHeight: _kAppBarHeight,
+    flexibleSpace: new LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final Size size = constraints.biggest;
+        final double appBarHeight = size.height - statusBarHeight;
+        final double t =
+            (appBarHeight - kToolbarHeight) / (_kAppBarHeight - kToolbarHeight);
+
+        return new Stack(
+          children: <Widget>[
+            buildHeader(topic, t),
+            buildAppBarTitle(statusBarHeight, t, context, topic.title),
+          ],
+        );
+      },
+    ),
+  );
+}
+
+Widget buildAppBarTitle(
+    double statusBarHeight, double t, BuildContext context, String title) {
+  final TextStyle textStyle = themeData.textTheme.title.merge(new TextStyle(
+    fontSize: 18.0,
+    color: Colors.white,
+  ));
+  final Curve _textOpacity = const Interval(0.4, 1.0, curve: Curves.easeInOut);
+  final Size screenSize = MediaQuery.of(context).size;
+  final double titleWidth =
+      screenSize.width - kToolbarHeight - NavigationToolbar.kMiddleSpacing;
+  final iOS = Theme.of(context).platform == TargetPlatform.iOS;
+
+  return new Positioned.fromRect(
+      rect: new Rect.fromLTWH(
+          iOS
+              ? kToolbarHeight - NavigationToolbar.kMiddleSpacing
+              : kToolbarHeight,
+          statusBarHeight,
+          titleWidth,
+          kToolbarHeight),
+      child: new Container(
+        alignment: iOS ? Alignment.center : Alignment.centerLeft,
+        child: new Opacity(
+          // 上にスクロールすると徐々に現れる
+          opacity: _textOpacity.transform(1 - t.clamp(0.0, 1.0)),
+          child: new Text(
+            title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: textStyle,
+          ),
+        ),
+      ));
+}
+
+Widget buildHeader(Topic topic, double t) {
+  final Curve _textOpacity = const Interval(0.4, 1.0, curve: Curves.easeInOut);
+
+  return new Opacity(
+    // 上にスクロールすると徐々に消えていく
+    opacity: _textOpacity.transform(t.clamp(0.0, 1.0)),
+    child: new Column(
+      mainAxisAlignment: MainAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        buildTitle(
+          topic.title,
+        ),
+        buildUserContent(
+          topic.user.imageUrl,
+          topic.user.id,
+        )
+      ],
+    ),
+  );
+}
+
+Widget buildBody(Topic topic, BuildContext context) {
+  final detailStyle = themeData.textTheme.body1;
+
+  return new SliverPadding(
+    padding: new EdgeInsets.all(16.0),
+    sliver: new SliverList(
+      delegate: new SliverChildListDelegate(
+        [
+          new Container(
+            constraints: new BoxConstraints(
+                minHeight: MediaQuery.of(context).size.height -
+                    MediaQuery.of(context).padding.top -
+                    kToolbarHeight),
+            margin: const EdgeInsets.only(top: 16.0),
+            child: new Text(
+              topic.body,
+              style: detailStyle,
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
+Widget buildTitle(String title) {
+  return new Container(
     child: new Text(
       title,
       style: new TextStyle(
@@ -58,7 +150,7 @@ Widget buildTitle(title) {
   );
 }
 
-Widget buildHeaderContents(imageUrl, name) {
+Widget buildUserContent(String imageUrl, String name) {
   return new Row(
     children: <Widget>[
       new Padding(

--- a/lib/ui/screen/home_screen.dart
+++ b/lib/ui/screen/home_screen.dart
@@ -71,14 +71,8 @@ class _MyListItem extends State<MyListItem> {
   Widget build(BuildContext context) {
     return new Container(
       child: new ListTile(
-        leading: widget.imageUrl != null
-              ? new Image.network(widget.imageUrl)
-              : new CircleAvatar(
-                  child: new Icon(
-                    Icons.account_circle,
-                    color: Colors.white,
-                    size: 32.0,
-                  ),
+        leading: new CircleAvatar(
+          backgroundImage: new NetworkImage(widget.imageUrl),
         ),
         trailing: new Row(
           children: <Widget>[

--- a/lib/ui/screen/home_screen.dart
+++ b/lib/ui/screen/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 import 'package:qiita_mitsuke_tatter/api/qiita_api.dart';
 import 'package:qiita_mitsuke_tatter/api/qiita_api_impl.dart';
 import 'package:qiita_mitsuke_tatter/model/topic.dart';
+import 'package:qiita_mitsuke_tatter/model/user.dart';
 import 'package:qiita_mitsuke_tatter/repository/qiita_repository_impl.dart';
 import 'package:qiita_mitsuke_tatter/ui/screen/detail_screen.dart';
 
@@ -41,26 +42,20 @@ class _MyHomePageState extends State<MyHomePage> {
         body: new ListView(
             children: topics.map((Topic topic) {
           return new MyListItem(
-            title: topic.title,
-            subTitle: topic.user.id,
-            imageUrl: topic.user.imageUrl,
-            favCounts: topic.likesCount,
+            topic: topic,
           );
         }).toList()));
   }
 }
 
 class MyListItem extends StatefulWidget {
-  MyListItem(
-      {Key key,
-      @required this.title,
-      @required this.subTitle,
-      @required this.imageUrl,
-      @required this.favCounts})
+  MyListItem({
+    Key key,
+    @required this.topic
+  })
       : super(key: key);
 
-  final String title, subTitle, imageUrl;
-  final int favCounts;
+  final Topic topic;
 
   @override
   _MyListItem createState() => new _MyListItem();
@@ -72,7 +67,9 @@ class _MyListItem extends State<MyListItem> {
     return new Container(
       child: new ListTile(
         leading: new CircleAvatar(
-          backgroundImage: new NetworkImage(widget.imageUrl),
+          backgroundImage: (widget.topic.user.imageUrl != null)
+              ? new NetworkImage(widget.topic.user.imageUrl)
+              : null,
         ),
         trailing: new Row(
           children: <Widget>[
@@ -81,7 +78,7 @@ class _MyListItem extends State<MyListItem> {
               color: Colors.pinkAccent,
             ),
             new Text(
-              widget.favCounts.toString(),
+              widget.topic.likesCount.toString(),
               style: const TextStyle(
                 color: Colors.pinkAccent,
               ),
@@ -90,18 +87,19 @@ class _MyListItem extends State<MyListItem> {
         ),
         isThreeLine: true,
         title: new Text(
-          widget.title,
+          widget.topic.title,
           overflow: TextOverflow.ellipsis,
           maxLines: 1,
         ),
         subtitle: new Text(
-          widget.subTitle,
+          widget.topic.user.id,
           maxLines: 3,
         ),
         onTap: () => Navigator.of(context).push(
               new MaterialPageRoute(
-                builder: (BuildContext context) =>
-                    new DetailScreen(title: widget.title),
+                builder: (BuildContext context) => new DetailScreen(
+                      topic: widget.topic,
+                    ),
               ),
             ),
       ),

--- a/lib/ui/screen/home_screen.dart
+++ b/lib/ui/screen/home_screen.dart
@@ -28,7 +28,7 @@ class _MyHomePageState extends State<MyHomePage> {
     QiitaApi api = new QiitaApiImpl();
     QiitaRepositoryImpl repo = new QiitaRepositoryImpl(api);
     repo.findTopic().then((topic) {
-      topics.addAll(topic);
+      setState(() => topics = topic);
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,10 @@ dependencies:
   flutter:
     sdk: flutter
 
+  flutter_markdown: ^0.1.2
+
+  url_launcher: ^2.0.1
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.0

--- a/qiita_mitsuke_tatter.iml
+++ b/qiita_mitsuke_tatter.iml
@@ -9,5 +9,6 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Dart Packages" level="project" />
+    <orderEntry type="library" name="Flutter Plugins" level="project" />
   </component>
 </module>


### PR DESCRIPTION
## 概要
- APIから取得したJsonデータ => HomeScreen、DetailScreenに反映
- DetailScreenは、某カンファレンスのFlutterアプリを参考にしてCoordinatorLayout + Appbarのような描画を実装
- 本文のデータであるbodyはHTMLかMarkdown系しかないので、`flutter_markdown`packageを使ってそれなりに描画
    - 内部のリンクは`url_launcher`を使って実装
        - 実装の際にパッケージ内部の`android/build.gradle`が若干設定がおかしくて動かなかったので修正
- ついでにAndroid SDK Versionを25 => 27にアップグレード

## スクリーンショット
<img width=50% src='https://user-images.githubusercontent.com/25450416/36644434-d71b340a-1a9d-11e8-8ab7-f581d1c36a1d.png'>
<img width=50% src='https://user-images.githubusercontent.com/25450416/36644446-ffdc1e90-1a9d-11e8-829d-5242c6abe7a8.png'>
<img width=50% src='https://user-images.githubusercontent.com/25450416/36644457-1dec531e-1a9e-11e8-98fe-da9aa2cc2e92.png'>